### PR TITLE
improve build script

### DIFF
--- a/deployHooks/stackery-build.sh
+++ b/deployHooks/stackery-build.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 mkdir -p .aws-sam/build/src/
-cp .stackery/template.yaml .aws-sam/build/template.yaml
+
+if [ -f .stackery/.stackery.template.yaml ]; then
+    cp .stackery/.stackery.template.yaml .aws-sam/build/template.yaml
+else
+    cp .stackery/template.yaml .aws-sam/build/template.yaml
+fi
 
 export GOPATH=$PWD
 


### PR DESCRIPTION
Address some confusion about whether we were working off of the user's template, or a template that had been worked on by the 'local invoke' code...

One concern is related to the possibility that a user could run 'local invoke' followed by 'local deploy'; local invoke ordinarily removes the .stackery.template.yaml, but if the user runs it with --debug it leaves that behind for debugging purposes, then when local deploy ran this script it would find the wrong template.  So some more head-scratching might be called for.
